### PR TITLE
Trying to fix build by using specific version of publish action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@1.10
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.9
         env:
           PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
Found the issue, I let the action developers know and have reverted to version 1.9 of the action.

Here's the issue: https://github.com/mhausenblas/mkdocs-deploy-gh-pages/issues/5