### PR TITLE
Specifically prohibit Vue and Angular

### DIFF
--- a/docs/topics/programming-languages.md
+++ b/docs/topics/programming-languages.md
@@ -30,6 +30,8 @@ Exceptions:
 Framework        | Permitted Versions | Notes
 ---------------- | ------------------ | ------------
 React            | > 16.10            |
+Create React App | > 3.0.0            |
+Next.js          | None               | Prohibited
 Angular          | None               | Prohibited
 Vue.js           | None               | Prohibited
 Java SDK         | Java SE 12         |

--- a/docs/topics/programming-languages.md
+++ b/docs/topics/programming-languages.md
@@ -25,11 +25,13 @@ Exceptions:
 
 ---
 
-## (PL-200) Framework Versions
+## (PL-200) Approved Frameworks
 
 Framework        | Permitted Versions | Notes
 ---------------- | ------------------ | ------------
 React            | > 16.10            |
+Angular          | None               | Prohibited
+Vue.js           | None               | Prohibited
 Java SDK         | Java SE 12         |
                  | Java SE 13         |
 Spring Framework | > 5.2.0            |


### PR DESCRIPTION
Don't necessarily need to call these out, but just to be clear, we're a React-only shop for the time being.

Thoughts?