### PR TITLE
Added some exceptions to Code Climate

### DIFF
--- a/docs/topics/code-quality.md
+++ b/docs/topics/code-quality.md
@@ -2,10 +2,13 @@
 
 ## (CQ-100) High Maintainability
 
-All repositories *must* maintain their `master` branch at a Code Climate
-maintainability score of C or above. This score *must* be updated at least
-once per day, ideally whenever code is merged into the `master` branch. The
-score must be displayed on the README at the root of the repository.
+Requirements:
+
+- All repositories *must* maintain their `master` branch at a Code Climate
+  maintainability score of C or above.
+- This score *must* be recalculated whenever code is pushed into the `master` branch.
+- The maintainability score must be displayed near the top of the README at the
+  root of the repository.
 
 Rationale:
 
@@ -15,16 +18,26 @@ Rationale:
 
 Exceptions:
 
-- Programming languages not supported by Code Climate.
+- The following types of repositories are excluded from this standard:
+    - Data science repos containing only Jupyter Notebooks
+    - Static websites not containing any code
+    - Repos containing only programming languages not supported by Code Climate
+- The following types of code can be excluded from your maintainability score:
+    - Test code
+    - Data migration code
 
 ---
 
-## (CQ-200) Robust Test Coverage
+## (CQ-110) Robust Test Coverage
 
-All repositories are required to maintain a test code coverage level of 30% and
-above for their `master` branch. Code coverage percentage *must* be updated at
-least once per day, ideally whenever code is merged into the `master` branch.
-The coverage percentage must be displayed on the README at the root of the repository.
+Requirements:
+
+- All repositories are required to maintain a code coverage level of 30%
+  or higher for their `master` branch.
+- Code coverage percentage *must* be published whenever code is pushed
+  into the `master` branch.
+- The code coverage percentage must be displayed near the top of the README at the
+  root of the repository.
 
 Rationale:
 
@@ -34,15 +47,20 @@ Rationale:
 
 Exceptions:
 
-- None
+- The following types of repositories are excluded from this standard:
+    - Data science repos containing only Jupyter Notebooks
+    - Static websites not containing any code
+- The following code can be excluded from your test coverage percentage:
+    - Test code
+    - Data migration code
 
 ---
 
-## (CQ-300) Code Cleanliness
+## (CQ-120) Code Cleanliness
 
 When code is no longer wanted, delete it. Never commit commented out code.
 
-PRs should not be approved when these comments are found.
+Pull requests should not be approved until these comments have been removed.
 
 Rationale:
 


### PR DESCRIPTION
Code Climate maintainability and coverage shouldn't apply to test code or data migration code. This will allow that code to be excluded.