### PR TITLE
Support Mixpanel and Segment for analytics

### DIFF
--- a/docs/topics/third-party-services.md
+++ b/docs/topics/third-party-services.md
@@ -276,7 +276,8 @@ listed below:
 
 * [Google Analytics](https://analytics.google.com/)
 * [Mixpanel](https://mixpanel.com/)
-* [Segment](https://segment.com/) - may be used to route analytics calls to Google Analytics _and_ Mixpanel.
+* [Segment](https://segment.com/) - may be used to route analytics calls to
+  Google Analytics _and_ Mixpanel.
 
 All others are prohibited from use.
 

--- a/docs/topics/third-party-services.md
+++ b/docs/topics/third-party-services.md
@@ -274,7 +274,9 @@ Exceptions:
 The only permitted user analytics services for Lambda School Labs projects are
 listed below:
 
-* Google Analytics
+* [Google Analytics](https://analytics.google.com/)
+* [Mixpanel](https://mixpanel.com/)
+* [Segment](https://segment.com/) - may be used to route analytics calls to Google Analytics _and_ Mixpanel.
 
 All others are prohibited from use.
 


### PR DESCRIPTION
Mixpanel and Google Analytics are both good at different things. GA is excellent for ecommerce-style "conversion tracking." Mixpanel is better for SaaS-like monitoring such as WAU, MAU, and cohort analysis. We should support Mixpanel.

Segment is useful as a router that allows Mixpanel, GA and other tools to be used without changing the code at all. Simply install Segment, and then you can turn on and off any analytics tracking through the Segment interface. This can be useful if you want to use both Mixpanel and GA.