### PR TITLE
GitHub add cohort admin team

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,11 +50,13 @@ ratified by approval from 3 Labs Tech Leads.
     - `> pipenv install --dev`
 2. Start a pipenv shell
     - `> pipenv shell`
-3. Run the markdown linter to confirm a clean start
-    - `> markdownlint -c .markdownlint.json .`
-4. Run the mkdocs server to build and view you local changes
+3. Run the mkdocs server to build and view you local changes
     - `> mkdocs serve`
     - Now open browser to `http://localhost:8000`
+4. install markdown linter
+    - `> npm install -g markdownlint-cli`
+5. Run the markdown linter before commiting
+    - `> markdownlint -c .markdownlint.json .`
 
     !!! Warning
         be aware that `mkdocs serve` serves the files directly from the docs

--- a/docs/topics/github.md
+++ b/docs/topics/github.md
@@ -22,6 +22,26 @@ Rationale:
 
 Exceptions:
 
+- TLs will be put into a cohort admin team with `Admin` role only on all
+  cohort repos.
+
+---
+
+## (GH-102) GitHub Cohort Admin Teams
+
+GitHub Cohort Admin teams need to be created using the following convention:
+
+- Name: `<Cohort> - Admins`  (Example: `Labs 20 - Admins`)
+
+Rationale:
+
+- Github repos don't allow a user to be added in addition to their team with
+  different roles. In order to allow TLs to be admins on their repos we need to
+  create this admins team so they can integrate the repo with external services
+  eg. Heroku and AWS.
+
+Exceptions:
+
 - None
 
 ---
@@ -65,12 +85,14 @@ Exceptions:
 GitHub project team membership and team roles will be as follows:
 
 - Section Lead ⇒ Maintainer
-- Team Lead ⇒ Maintainer
+- Team Lead ⇒ Admin
 - Student ⇒ Member
 
 Rationale:
 
 - Least privilege access
+- The `<cohort> - Admins` team will need to be added to each repo with
+  admin role.
 
 Exceptions:
 


### PR DESCRIPTION
I added this to the org level since it is a stop gap to allow TLs to admin the repo and connect to external services.