### PR TITLE
AWS Standards

### DIFF
--- a/docs/topics/aws.md
+++ b/docs/topics/aws.md
@@ -1,0 +1,28 @@
+# AWS
+
+## (AW-100) Approved AWS Services
+
+The only permitted AWS services for Lambda School Labs projects are listed below:
+
+* Amplify
+    * Front-end hosting of Single Page Apps (SPA) only
+* Elastic Beanstalk
+* Sagemaker
+
+All others are prohibited from use.
+
+Note: These services utilize many underlying services, which are permitted only
+when provisioned by the orchestration services listed above.
+
+Rationale:
+
+* AWS is _very_ deep, with many different services and components. That complexity
+  needs careful controls to reduce risk and cost.
+
+Alternatives:
+
+* None
+
+Exceptions:
+
+* None

--- a/docs/topics/third-party-services.md
+++ b/docs/topics/third-party-services.md
@@ -31,6 +31,7 @@ Exceptions:
 The only permitted hosting providers for Lambda School Labs projects are listed below:
 
 * Amazon Web Services (AWS)
+    * See [AWS Standards](aws.md) for more detail
 * Heroku
 
 All others are prohibited from use, including:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-mkdocs-material==4.6.0
-Pygments==2.5.2
-pymdown-extensions==6.2.1


### PR DESCRIPTION
Limit the use of AWS services as we build out controls, guides and curriculum.