### PR TITLE
Exclude GraphQL

### DIFF
--- a/docs/topics/web-api-frameworks.md
+++ b/docs/topics/web-api-frameworks.md
@@ -5,6 +5,9 @@
 Only the following web API frameworks are approved for projects in Labs:
 
 - REST
+
+All other API types are prohibited, including:
+
 - GraphQL
 
 Rationale:


### PR DESCRIPTION
GraphQL has proved to be to low on the maturity curve to effectively manage in Labs. We should revisit from time to time to see if there is a framework that's stable enough to work in our environment.