### PR TITLE
move apollo client to exceptions with clause for 3rd party services only

### DIFF
--- a/docs/topics/react.md
+++ b/docs/topics/react.md
@@ -8,8 +8,6 @@ Only the following Node.js package managers are approved for projects in Labs:
     - Version > 7.1
 - [Context API](https://reactjs.org/docs/context.html)
     - N/A
-- [Apollo Client](https://www.apollographql.com/docs/react/)
-    - Version > 2.6
 
 Rationale:
 
@@ -23,4 +21,6 @@ Alternatives:
 
 Exceptions:
 
-- None
+- [Apollo Client](https://www.apollographql.com/docs/react/)
+    - Version > 2.6
+    - For use in accessing third party services


### PR DESCRIPTION
As we've removed graphql as a API protocol I moved the client to the exception in react. The thinking is that they may use a service with only a graphql api.