### PR TITLE
Replace cypress with jest/rtl

### DIFF
--- a/docs/topics/react.md
+++ b/docs/topics/react.md
@@ -25,8 +25,8 @@ Exceptions:
 
 ## (RE-200) Approved Testing Frameworks
 
--   [Cypress](https://www.cypress.io/)
-    -   Version > 4.0.0
+-   [Jest](https://jestjs.io/)
+    -   combined with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro)
 
 Rationale:
 


### PR DESCRIPTION
A TPL noticed that our standards still showed Cypress as the only approved react testing framework. I changed it to reflect the use of jest and RTL in the scaffold.